### PR TITLE
Update DataTransfer4InfoPage.xaml.cs

### DIFF
--- a/Chapter24/DataTransfer4/DataTransfer4/DataTransfer4/DataTransfer4InfoPage.xaml.cs
+++ b/Chapter24/DataTransfer4/DataTransfer4/DataTransfer4/DataTransfer4InfoPage.xaml.cs
@@ -54,6 +54,8 @@ namespace DataTransfer4
             {
                 list.Add(info);
             }
+            
+            app.SetListViewMainPage();
         }
     }
 }


### PR DESCRIPTION
The draft for the Win when calling OnListViewItemSelected fails in binding the listView.ItemsSource = list. Innovation validated for Android and Win. (Сhanges in the three files - App.Xaml.cs, DataTransfer4HomePage.Xaml.cs, DataTransfer4InfoPage.Xaml.cs.)