### PR TITLE
Update DataTransfer4HomePage.xaml.cs

### DIFF
--- a/Chapter24/DataTransfer4/DataTransfer4/DataTransfer4/DataTransfer4HomePage.xaml.cs
+++ b/Chapter24/DataTransfer4/DataTransfer4/DataTransfer4/DataTransfer4HomePage.xaml.cs
@@ -11,8 +11,8 @@ namespace DataTransfer4
         {
             InitializeComponent();
 
-            // Set collection to ListView.
-            listView.ItemsSource = app.InfoCollection;
+            // Set collection to ListView   - don't work for Win!!! (07 May 2017)
+            // listView.ItemsSource = app.InfoCollection;
         }
 
         // Button Clicked handler.


### PR DESCRIPTION
The draft for the Win when calling OnListViewItemSelected fails in binding the listView.ItemsSource = list. Innovation validated for Android and Win. (Сhanges in the three files - App.Xaml.cs, DataTransfer4HomePage.Xaml.cs, DataTransfer4InfoPage.Xaml.cs.)