### PR TITLE
Fix build error of Chapter24/NoteTaker

### DIFF
--- a/Chapter24/NoteTaker/NoteTaker/NoteTaker.Droid/MainActivity.cs
+++ b/Chapter24/NoteTaker/NoteTaker/NoteTaker.Droid/MainActivity.cs
@@ -17,7 +17,7 @@ namespace NoteTaker.Droid
             base.OnCreate(bundle);
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
-            Xamarin.FormsBook.Platform.Android.Toolkit.Init();
+            Xamarin.FormsBook.Platform.Android.Toolkit.Init(this, bundle);
             LoadApplication(new App());
         }
     }


### PR DESCRIPTION
Just supplying missing arguments in `MainActivity` constructor.