### PR TITLE
Update ImageResourceExtension.cs

### DIFF
--- a/Chapter13/StackedBitmap/StackedBitmap/StackedBitmap/ImageResourceExtension.cs
+++ b/Chapter13/StackedBitmap/StackedBitmap/StackedBitmap/ImageResourceExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Xamarin.Forms.Xaml;
 using Xamarin.Forms;
 
@@ -13,8 +14,13 @@ namespace StackedBitmap
         {
             if (Source == null)
                 return null;
+                
+            var assembly = typeof(ImageResourceExtension).GetTypeInfo().Assembly;
 
-            return ImageSource.FromResource(Source); 
+            if (assembly == null)
+                return null;
+
+            return ImageSource.FromResource(Source, assembly); 
         }
     }
 }


### PR DESCRIPTION
Feature version "ImageSource. Fromresource"  without "Assembly" parameter does not work in .net Standard 2.0! A correction of the situation is suggested. The images must be in the same assembly that uses them.