### PR TITLE
Bouncing Box is not visible in BouncingBox demo

### DIFF
--- a/Chapter22/BouncingBox/BouncingBox/BouncingBox/BouncingBoxPage.xaml.cs
+++ b/Chapter22/BouncingBox/BouncingBox/BouncingBox/BouncingBoxPage.xaml.cs
@@ -33,6 +33,7 @@ namespace BouncingBox
             if (!animationGoing && layoutSize > 100)
             {
                 animationGoing = true;
+                boxView.IsVisible = true;
                 AnimationLoop();
             }
         }


### PR DESCRIPTION
The bouncing box was never made visible in the code for this demo.  Adding the setting at Line 36 in BouncingBoxPage.xaml.cs fixes it.