### PR TITLE
Explicitly list fs files in fsprojs.

### DIFF
--- a/Chapter02/FS/Greetings/Greetings/Greetings.fsproj
+++ b/Chapter02/FS/Greetings/Greetings/Greetings.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="GreetingsPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter02/FS/Hello/Hello/Hello.fsproj
+++ b/Chapter02/FS/Hello/Hello/Hello.fsproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter03/FS/Baskervilles/Baskervilles/Baskervilles/Baskervilles.fsproj
+++ b/Chapter03/FS/Baskervilles/Baskervilles/Baskervilles/Baskervilles.fsproj
@@ -11,5 +11,9 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
-
+  <ItemGroup>
+    <Compile Include="BaskervillesPage.fs" />
+    <Compile Include="App.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter03/FS/NamedFontSizes/NamedFontSizes/NamedFontSizes/NamedFontSizes.fsproj
+++ b/Chapter03/FS/NamedFontSizes/NamedFontSizes/NamedFontSizes/NamedFontSizes.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="NamedFontSizesPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter03/FS/VariableFormPara/VariableFormattedParagraph/VariableFormattedParagraph/VariableFormattedParagraph.fsproj
+++ b/Chapter03/FS/VariableFormPara/VariableFormattedParagraph/VariableFormattedParagraph/VariableFormattedParagraph.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="VarFormParaPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter03/FS/VariableFormText/VariableFormattedText/VariableFormattedText/VariableFormattedText.fsproj
+++ b/Chapter03/FS/VariableFormText/VariableFormattedText/VariableFormattedText/VariableFormattedText.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="VariableFormattedTextPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter04/FS/BlackCat/BlackCat/BlackCat/BlackCat.fsproj
+++ b/Chapter04/FS/BlackCat/BlackCat/BlackCat/BlackCat.fsproj
@@ -14,6 +14,9 @@
 
   <ItemGroup>
     <EmbeddedResource Include="TheBlackCat.txt" />
+    <Compile Include="BlackCatPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
   </ItemGroup>
 
 </Project>

--- a/Chapter04/FS/ColorBlocks/ColorBlocks/ColorBlocks/ColorBlocks.fsproj
+++ b/Chapter04/FS/ColorBlocks/ColorBlocks/ColorBlocks/ColorBlocks.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="ColorBlocksPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter04/FS/ColorList/ColorList/ColorList/ColorList.fsproj
+++ b/Chapter04/FS/ColorList/ColorList/ColorList/ColorList.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="ColorListPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter04/FS/ColorLoop/ColorLoop/ColorLoop/ColorLoop.fsproj
+++ b/Chapter04/FS/ColorLoop/ColorLoop/ColorLoop/ColorLoop.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="ColorLoopPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter04/FS/FramedText/FramedText/FramedText/FramedText.fsproj
+++ b/Chapter04/FS/FramedText/FramedText/FramedText/FramedText.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="FramedTextPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter04/FS/ReflectedColors/ReflectedColors/ReflectedColors/ReflectedColors.fsproj
+++ b/Chapter04/FS/ReflectedColors/ReflectedColors/ReflectedColors/ReflectedColors.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="ReflectedColorsPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter04/FS/SizedBoxView/SizedBoxView/SizedBoxView/SizedBoxView.fsproj
+++ b/Chapter04/FS/SizedBoxView/SizedBoxView/SizedBoxView/SizedBoxView.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="SizedBoxViewPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter04/FS/VerticalOptionsDemo/VerticalOptionsDemo/VerticalOptionsDemo/VerticalOptionsDemo.fsproj
+++ b/Chapter04/FS/VerticalOptionsDemo/VerticalOptionsDemo/VerticalOptionsDemo/VerticalOptionsDemo.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="VerticalOptionsDemoPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter05/FS/EmpiricalFontSize/EmpiricalFontSize/EmpiricalFontSize/EmpiricalFontSize.fsproj
+++ b/Chapter05/FS/EmpiricalFontSize/EmpiricalFontSize/EmpiricalFontSize/EmpiricalFontSize.fsproj
@@ -12,4 +12,10 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="FontCalc.fs" />
+    <Compile Include="EmpiricalFontSizePage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter05/FS/EstimatedFontSize/EstimatedFontSize/EstimatedFontSize/EstimatedFontSize.fsproj
+++ b/Chapter05/FS/EstimatedFontSize/EstimatedFontSize/EstimatedFontSize/EstimatedFontSize.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="EstimatedFontSizePage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter05/FS/FitToSizeClock/FitToSizeClock/FitToSizeClock/FitToSizeClock.fsproj
+++ b/Chapter05/FS/FitToSizeClock/FitToSizeClock/FitToSizeClock/FitToSizeClock.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="FitToSizeClockPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Add.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter05/FS/FontSizes/FontSizes/FontSizes/FontSizes.fsproj
+++ b/Chapter05/FS/FontSizes/FontSizes/FontSizes/FontSizes.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="FontSizesPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter05/FS/MetricalBoxView/MetricalBoxView/MetricalBoxView/MetricalBoxView.fsproj
+++ b/Chapter05/FS/MetricalBoxView/MetricalBoxView/MetricalBoxView/MetricalBoxView.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="MetricalBoxViewPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter05/FS/WhatSize/WhatSize/WhatSize/WhatSize.fsproj
+++ b/Chapter05/FS/WhatSize/WhatSize/WhatSize/WhatSize.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="WhatSizePage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Add.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter06/FS/ButtonLambdas/ButtonLambdas/ButtonLambdas/ButtonLambdas.fsproj
+++ b/Chapter06/FS/ButtonLambdas/ButtonLambdas/ButtonLambdas/ButtonLambdas.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="ButtonLambdasPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter06/FS/ButtonLogger/ButtonLogger/ButtonLogger/ButtonLogger.fsproj
+++ b/Chapter06/FS/ButtonLogger/ButtonLogger/ButtonLogger/ButtonLogger.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="ButtonLoggerPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter06/FS/PersistentKeypad/PersistentKeypad/PersistentKeypad/PersistentKeypad.fsproj
+++ b/Chapter06/FS/PersistentKeypad/PersistentKeypad/PersistentKeypad/PersistentKeypad.fsproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="PersistentKeypadPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter06/FS/SimplestKeypad/SimplestKeypad/SimplestKeypad/SimplestKeypad.fsproj
+++ b/Chapter06/FS/SimplestKeypad/SimplestKeypad/SimplestKeypad/SimplestKeypad.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="SimplestKeypadPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter06/FS/TwoButtons/TwoButtons/TwoButtons/TwoButtons.fsproj
+++ b/Chapter06/FS/TwoButtons/TwoButtons/TwoButtons/TwoButtons.fsproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.637273" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="TwoButtonsPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter07/FS/CodePlusXaml/CodePlusXaml/CodePlusXaml/CodePlusXaml.fsproj
+++ b/Chapter07/FS/CodePlusXaml/CodePlusXaml/CodePlusXaml/CodePlusXaml.fsproj
@@ -18,4 +18,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="CodePlusXamlPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+  </ItemGroup>
 </Project>

--- a/Chapter08/FS/XamlKeypad/XamlKeypad/XamlKeypad/XamlKeypad.fsproj
+++ b/Chapter08/FS/XamlKeypad/XamlKeypad/XamlKeypad/XamlKeypad.fsproj
@@ -18,4 +18,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="XamlKeypadPage.fs" />
+    <Compile Include="AssemblyInfo.fs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
F# SDK style projects must explicitly list the .fs files, because the order matters.

Reference: https://xamarinhq.slack.com/archives/C0VFPK631/p1553850714002700

Fixes compiler errors like these:

    "xamarin-forms-book-samples/Chapter03/FS/Baskervilles/Baskervilles/Baskervilles.iOS/Baskervilles.iOS.csproj" (default target) (1) ->
    (CoreCompile target) ->
      AppDelegate.cs(26,33): error CS0246: The type or namespace name 'App' could not be found (are you missing a using directive or an assembly reference?) [xamarin-forms-book-samples/Chapter03/FS/Baskervilles/Baskervilles/Baskervilles.iOS/Baskervilles.iOS.csproj]