### PR TITLE
Add missing Entitlement.plists.

### DIFF
--- a/Chapter02/FS/Greetings/Greetings.iOS/Entitlements.plist
+++ b/Chapter02/FS/Greetings/Greetings.iOS/Entitlements.plist
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>
+

--- a/Chapter02/FS/Hello/Hello.iOS/Entitlements.plist
+++ b/Chapter02/FS/Hello/Hello.iOS/Entitlements.plist
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>
+


### PR DESCRIPTION
Add an Entitlement.plist file to projects whose project file references one.

Fixes build errors such as:

    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(1498,3): error : Entitlements.plist template 'Entitlements.plist' not found. [xamarin-forms-book-samples/Chapter02/FS/Hello/Hello.iOS/Hello.iOS.fsproj]
    /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(1498,3): error : Entitlements.plist template 'Entitlements.plist' not found. [xamarin-forms-book-samples/Chapter02/FS/Hello/Hello.iOS/Hello.iOS.fsproj]